### PR TITLE
Meta: Optimize PR warning insertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "devDependencies": {
     "@tc39/ecma262-biblio": "^2.1.2775",
     "ecmarkup": "^20.0.0",
-    "jsdom": "^25.0.1"
+    "jsdom": "^25.0.1",
+    "parse5-html-rewriting-stream": "^7.0.0",
+    "tmp": "^0.2.3"
   },
   "engines": {
     "node": ">= 12"


### PR DESCRIPTION
* Use more specific error types.
* For compatibility, switch from `import(jsonFileName)` to `JSON.parse(readFile(jsonFileName))`.
* For performance, rather than parsing HTML into a complete AST, use a streaming rewriter (and switch to passthrough after prepending to `<body>`).