### PR TITLE
Editorial: Fix typos

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -491,7 +491,7 @@ contributors: Mark S. Miller, Richard Gibson
             1. Let _newBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(_constructor_, _byteLength_, ~immutable~)</emu-meta>.
             1. Let _toBlock_ be _newBuffer_.[[ArrayBufferData]].
             1. NOTE: This is the only step that can write into the Data Block of an immutable ArrayBuffer.
-            1. Perform CopyDataBlockBytes(_toBlock_, 0, _fromBlock_, 0, _count_).
+            1. Perform CopyDataBlockBytes(_toBlock_, 0, _fromBlock_, _fromIndex_, _count_).
             1. Return _newBuffer_.
           </emu-alg>
           <emu-note>

--- a/spec.emu
+++ b/spec.emu
@@ -490,6 +490,7 @@ contributors: Mark S. Miller, Richard Gibson
             1. Assert: _count_ ≤ _byteLength_.
             1. Let _newBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(_constructor_, _byteLength_, ~immutable~)</emu-meta>.
             1. Let _toBlock_ be _newBuffer_.[[ArrayBufferData]].
+            1. NOTE: This is the only step that can write into the Data Block of an immutable ArrayBuffer.
             1. Perform CopyDataBlockBytes(_toBlock_, 0, _fromBlock_, 0, _count_).
             1. Return _newBuffer_.
           </emu-alg>
@@ -529,7 +530,6 @@ contributors: Mark S. Miller, Richard Gibson
           1. Let _newBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _newByteLength_, _newMaxByteLength_)</emu-meta>.
           1. <del>Let _copyLength_ be min(_newByteLength_, _arrayBuffer_.[[ArrayBufferByteLength]]).</del>
           1. Let _fromBlock_ be _arrayBuffer_.[[ArrayBufferData]].
-          1. <ins>NOTE: This is the only step that can write into the Data Block of an immutable ArrayBuffer.</ins>
           1. Let _toBlock_ be _newBuffer_.[[ArrayBufferData]].
           1. Perform CopyDataBlockBytes(_toBlock_, 0, _fromBlock_, 0, _copyLength_).
           1. NOTE: Neither creation of the new Data Block nor copying from the old Data Block are observable. Implementations may implement this method as a zero-copy move or a `realloc`.

--- a/spec.emu
+++ b/spec.emu
@@ -717,19 +717,20 @@ contributors: Mark S. Miller, Richard Gibson
             1. Let _O_ be the *this* value.
             1. Perform ? RequireInternalSlot(_O_, [[ArrayBufferData]]).
             1. If IsSharedArrayBuffer(_O_) is *true*, throw a *TypeError* exception.
-            1. TODO: Confirm inclusion of this redundant check.
             1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
             1. Let _len_ be _O_.[[ArrayBufferByteLength]].
             1. Let _bounds_ be ? ResolveBounds(_len_, _start_, _end_).
             1. Let _first_ be _bounds_.[[From]].
             1. Let _final_ be _bounds_.[[To]].
-            1. TODO: Confirm this strictness vs. the conventional `max(_final_ - _first_, 0)`.
             1. Let _newLen_ be _final_ - _first_.
+            1. TODO: Confirm this strictness vs. `slice` (rejecting negative _newLen_ rather than clamping to 0).
             1. If _newLen_ &lt; 0, throw a *RangeError* exception.
-            1. Let _copyLen_ be min(_newLen_, _len_).
-            1. NOTE: Side-effects of the above steps may have detached or resized _O_. This algorithm proceeds only when _O_ is not detached, even if _newLen_ is 0.
+            1. NOTE: Side-effects of the above steps may have detached or resized _O_.
             1. If IsDetachedBuffer(_O_) is *true*, throw a *TypeError* exception.
-            1. Let _newBuffer_ be ? AllocateImmutableArrayBuffer(%ArrayBuffer%, _newLen_, _O_.[[ArrayBufferData]], _first_, _copyLen_).
+            1. Let _fromBuf_ be _O_.[[ArrayBufferData]].
+            1. Let _currentLen_ be _O_.[[ArrayBufferByteLength]].
+            1. If _currentLen_ &lt; _final_, throw a *RangeError* exception.
+            1. Let _newBuffer_ be ? AllocateImmutableArrayBuffer(%ArrayBuffer%, _newLen_, _fromBuf_, _first_, _newLen_).
             1. Return _newBuffer_.
           </emu-alg>
         </emu-clause>


### PR DESCRIPTION
* Move note about immutable ArrayBuffer Data Block initialization to the correct step 
* Better align ArrayBuffer.p.sliceToImmutable with slice
* Fix obviously incorrect failure to propagate argument