### PR TITLE
Editorial: Split TypedArray [[DefineOwnProperty]] into distinct branches by mutability

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -99,21 +99,17 @@ contributors: Mark S. Miller, Richard Gibson
             1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
               1. If IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *false*.
-              1. <ins>If _Desc_ has an [[Enumerable]] field and _Desc_.[[Enumerable]] is *false*, return *false*.</ins>
-              1. <ins>If IsAccessorDescriptor(_Desc_) is *true*, return *false*.</ins>
-              1. <ins>If IsImmutableBuffer(_O_.[[ViewedArrayBuffer]]) is *false*, then</ins>
-                1. If _Desc_ has a [[Configurable]] field and _Desc_.[[Configurable]] is *false*, return *false*.
-                1. <del>If _Desc_ has an [[Enumerable]] field and _Desc_.[[Enumerable]] is *false*, return *false*.</del>
-                1. <del>If IsAccessorDescriptor(_Desc_) is *true*, return *false*.</del>
-                1. If _Desc_ has a [[Writable]] field and _Desc_.[[Writable]] is *false*, return *false*.
-                1. If _Desc_ has a [[Value]] field, perform ? TypedArraySetElement(_O_, _numericIndex_, _Desc_.[[Value]]).
-                1. Return *true*.
-              1. <ins>Else,</ins>
-                1. <ins>If _Desc_ has a [[Configurable]] field and _Desc_.[[Configurable]] is *true*, return *false*.</ins>
-                1. <ins>If _Desc_ has a [[Writable]] field and _Desc_.[[Writable]] is *true*, return *false*.</ins>
+              1. <ins>If IsImmutableBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, then</ins>
+                1. <ins>Let _current_ be ! <emu-meta suppress-effects="user-code">_O_.[[GetOwnProperty]](_P_)</emu-meta>.</ins>
+                1. <ins>Assert: _current_.[[Configurable]] and _current_.[[Writable]] are both *false*.</ins>
                 1. <ins>NOTE: Attempting to redefine an immutable value always fails, even if the new value would be cast to the current value.</ins>
-                1. <ins>If _Desc_ has a [[Value]] field and SameValue(_Desc_.[[Value]], TypedArrayGetElement(_O_, _numericIndex_)) is *false*, return *false*.</ins>
-                1. <ins>Return *true*.</ins>
+                1. <ins>Return ValidateAndApplyPropertyDescriptor(_O_, _P_, *false*, _Desc_, _current_).</ins>
+              1. If _Desc_ has a [[Configurable]] field and _Desc_.[[Configurable]] is *false*, return *false*.
+              1. If _Desc_ has an [[Enumerable]] field and _Desc_.[[Enumerable]] is *false*, return *false*.
+              1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
+              1. If _Desc_ has a [[Writable]] field and _Desc_.[[Writable]] is *false*, return *false*.
+              1. If _Desc_ has a [[Value]] field, perform ? TypedArraySetElement(_O_, _numericIndex_, _Desc_.[[Value]]).
+              1. Return *true*.
           1. Return ! OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
         </emu-alg>
       </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -99,18 +99,21 @@ contributors: Mark S. Miller, Richard Gibson
             1. Let _numericIndex_ be CanonicalNumericIndexString(_P_).
             1. If _numericIndex_ is not *undefined*, then
               1. If IsValidIntegerIndex(_O_, _numericIndex_) is *false*, return *false*.
-              1. <ins>Let _mutable_ be *true*.</ins>
-              1. <ins>If IsImmutableBuffer(_O_.[[ViewedArrayBuffer]]) is *true*, set _mutable_ to *false*.</ins>
-              1. If _Desc_ has a [[Configurable]] field and _Desc_.[[Configurable]] is <del>*false*</del> <ins>not _mutable_</ins>, return *false*.
-              1. If _Desc_ has an [[Enumerable]] field and _Desc_.[[Enumerable]] is *false*, return *false*.
-              1. If IsAccessorDescriptor(_Desc_) is *true*, return *false*.
-              1. If _Desc_ has a [[Writable]] field and _Desc_.[[Writable]] is <del>*false*</del> <ins>not _mutable_</ins>, return *false*.
-              1. <del>If _Desc_ has a [[Value]] field, perform ? TypedArraySetElement(_O_, _numericIndex_, _Desc_.[[Value]]).</del>
-              1. <ins>If _Desc_ has a [[Value]] field, then</ins>
+              1. <ins>If _Desc_ has an [[Enumerable]] field and _Desc_.[[Enumerable]] is *false*, return *false*.</ins>
+              1. <ins>If IsAccessorDescriptor(_Desc_) is *true*, return *false*.</ins>
+              1. <ins>If IsImmutableBuffer(_O_.[[ViewedArrayBuffer]]) is *false*, then</ins>
+                1. If _Desc_ has a [[Configurable]] field and _Desc_.[[Configurable]] is *false*, return *false*.
+                1. <del>If _Desc_ has an [[Enumerable]] field and _Desc_.[[Enumerable]] is *false*, return *false*.</del>
+                1. <del>If IsAccessorDescriptor(_Desc_) is *true*, return *false*.</del>
+                1. If _Desc_ has a [[Writable]] field and _Desc_.[[Writable]] is *false*, return *false*.
+                1. If _Desc_ has a [[Value]] field, perform ? TypedArraySetElement(_O_, _numericIndex_, _Desc_.[[Value]]).
+                1. Return *true*.
+              1. <ins>Else,</ins>
+                1. <ins>If _Desc_ has a [[Configurable]] field and _Desc_.[[Configurable]] is *true*, return *false*.</ins>
+                1. <ins>If _Desc_ has a [[Writable]] field and _Desc_.[[Writable]] is *true*, return *false*.</ins>
                 1. <ins>NOTE: Attempting to redefine an immutable value always fails, even if the new value would be cast to the current value.</ins>
-                1. <ins>If _mutable_ is *false* and SameValue(_Desc_.[[Value]], TypedArrayGetElement(_O_, _numericIndex_)) is *false*, return *false*.</ins>
-                1. <ins>If _mutable_ is *true*, perform ? TypedArraySetElement(_O_, _numericIndex_, _Desc_.[[Value]]).</ins>
-              1. Return *true*.
+                1. <ins>If _Desc_ has a [[Value]] field and SameValue(_Desc_.[[Value]], TypedArrayGetElement(_O_, _numericIndex_)) is *false*, return *false*.</ins>
+                1. <ins>Return *true*.</ins>
           1. Return ! OrdinaryDefineOwnProperty(_O_, _P_, _Desc_).
         </emu-alg>
       </emu-clause>


### PR DESCRIPTION
Ref #27

The first commit preserves explicit steps, the second defers the immutable branch to [ValidateAndApplyPropertyDescriptor](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-validateandapplypropertydescriptor).