### PR TITLE
Normative: Fix ArrayBufferCopyAndDetach

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -454,20 +454,22 @@ contributors: Mark S. Miller, Richard Gibson
             1. Let _newByteLength_ be ? ToIndex(_newLength_).
           1. If IsDetachedBuffer(_arrayBuffer_) is *true*, throw a *TypeError* exception.
           1. <ins>If IsImmutableBuffer(_arrayBuffer_) is *true*, throw a *TypeError* exception.</ins>
+          1. <ins>If _arrayBuffer_.[[ArrayBufferDetachKey]] is not *undefined*, throw a *TypeError* exception.</ins>
           1. <ins>Let _copyLength_ be min(_newByteLength_, _arrayBuffer_.[[ArrayBufferByteLength]]).</ins>
           1. <ins>If _preserveResizability_ is ~immutable~, then</ins>
-            1. <ins>Return ? AllocateImmutableArrayBuffer(%ArrayBuffer%, _newByteLength_, _arrayBuffer_.[[ArrayBufferData]], 0, _copyLength_).</ins>
-          1. If _preserveResizability_ is ~preserve-resizability~ and IsFixedLengthArrayBuffer(_arrayBuffer_) is *false*, then
-            1. Let _newMaxByteLength_ be _arrayBuffer_.[[ArrayBufferMaxByteLength]].
-          1. Else,
-            1. Let _newMaxByteLength_ be ~empty~.
-          1. If _arrayBuffer_.[[ArrayBufferDetachKey]] is not *undefined*, throw a *TypeError* exception.
-          1. Let _newBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _newByteLength_, _newMaxByteLength_)</emu-meta>.
-          1. <del>Let _copyLength_ be min(_newByteLength_, _arrayBuffer_.[[ArrayBufferByteLength]]).</del>
-          1. Let _fromBlock_ be _arrayBuffer_.[[ArrayBufferData]].
-          1. Let _toBlock_ be _newBuffer_.[[ArrayBufferData]].
-          1. Perform CopyDataBlockBytes(_toBlock_, 0, _fromBlock_, 0, _copyLength_).
-          1. NOTE: Neither creation of the new Data Block nor copying from the old Data Block are observable. Implementations may implement this method as a zero-copy move or a `realloc`.
+            1. <ins>Let _newBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateImmutableArrayBuffer(%ArrayBuffer%, _newByteLength_, _arrayBuffer_.[[ArrayBufferData]], 0, _copyLength_)</emu-meta>.</ins>
+          1. <ins>Else,</ins>
+            1. If _preserveResizability_ is ~preserve-resizability~ and IsFixedLengthArrayBuffer(_arrayBuffer_) is *false*, then
+              1. Let _newMaxByteLength_ be _arrayBuffer_.[[ArrayBufferMaxByteLength]].
+            1. Else,
+              1. Let _newMaxByteLength_ be ~empty~.
+            1. <del>If _arrayBuffer_.[[ArrayBufferDetachKey]] is not *undefined*, throw a *TypeError* exception.</del>
+            1. Let _newBuffer_ be ? <emu-meta suppress-effects="user-code">AllocateArrayBuffer(%ArrayBuffer%, _newByteLength_, _newMaxByteLength_)</emu-meta>.
+            1. <del>Let _copyLength_ be min(_newByteLength_, _arrayBuffer_.[[ArrayBufferByteLength]]).</del>
+            1. Let _fromBlock_ be _arrayBuffer_.[[ArrayBufferData]].
+            1. Let _toBlock_ be _newBuffer_.[[ArrayBufferData]].
+            1. Perform CopyDataBlockBytes(_toBlock_, 0, _fromBlock_, 0, _copyLength_).
+            1. NOTE: Neither creation of the new Data Block nor copying from the old Data Block are observable. Implementations may implement this method as a zero-copy move or a `realloc`.
           1. Perform ! DetachArrayBuffer(_arrayBuffer_).
           1. Return _newBuffer_.
         </emu-alg>


### PR DESCRIPTION
Ref #31

* Always respect [[ArrayBufferDetachKey]].
* Always detach.